### PR TITLE
PS-10209: Configurable bundle RFQ and "Quantity in the Cart" (phase 1).

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -6,7 +6,7 @@
   "require": {
     "php": ">=7.1",
     "spryker/calculation": "^4.0.0",
-    "spryker/cart-extension": "^1.8.0 || ^2.4.0 || ^4.0.0",
+    "spryker/cart-extension": "^1.9.0 || ^2.5.0 || ^4.1.0",
     "spryker/kernel": "^3.19.0",
     "spryker/messenger": "^3.1.0",
     "spryker/quote": "^2.10.0",

--- a/src/Spryker/Client/Cart/CartClient.php
+++ b/src/Spryker/Client/Cart/CartClient.php
@@ -178,6 +178,48 @@ class CartClient extends AbstractClient implements CartClientInterface
      *
      * @api
      *
+     * @param \Generated\Shared\Transfer\CartChangeTransfer $cartChangeTransfer
+     *
+     * @return \Generated\Shared\Transfer\QuoteResponseTransfer
+     */
+    public function addToCart(CartChangeTransfer $cartChangeTransfer): QuoteResponseTransfer
+    {
+        return $this->getFactory()->createQuoteStorageStrategyProxy()->addToCart($cartChangeTransfer);
+    }
+
+    /**
+     * {@inheritdoc}
+     *
+     * @api
+     *
+     * @param \Generated\Shared\Transfer\CartChangeTransfer $cartChangeTransfer
+     *
+     * @return \Generated\Shared\Transfer\QuoteResponseTransfer
+     */
+    public function removeFromCart(CartChangeTransfer $cartChangeTransfer): QuoteResponseTransfer
+    {
+        return $this->getFactory()->createQuoteStorageStrategyProxy()->removeFromCart($cartChangeTransfer);
+    }
+
+    /**
+     * {@inheritdoc}
+     *
+     * @api
+     *
+     * @param \Generated\Shared\Transfer\CartChangeTransfer $cartChangeTransfer
+     *
+     * @return \Generated\Shared\Transfer\QuoteResponseTransfer
+     */
+    public function updateQuantity(CartChangeTransfer $cartChangeTransfer): QuoteResponseTransfer
+    {
+        return $this->getFactory()->createQuoteStorageStrategyProxy()->updateQuantity($cartChangeTransfer);
+    }
+
+    /**
+     * {@inheritdoc}
+     *
+     * @api
+     *
      * @param string $sku
      * @param string|null $groupKey
      * @param int $quantity

--- a/src/Spryker/Client/Cart/CartClientInterface.php
+++ b/src/Spryker/Client/Cart/CartClientInterface.php
@@ -149,6 +149,56 @@ interface CartClientInterface
      * Specification:
      *  - Resolve quote storage strategy which implements \Spryker\Client\CartExtension\Dependency\Plugin\QuoteStorageStrategyPluginInterface.
      *  - Default quote storage strategy \Spryker\Client\Cart\Plugin\SessionQuoteStorageStrategyPlugin.
+     *  - Uses quote storage strategy.
+     *  - Adds items to cart.
+     *  - Increases quantity for items that are already in cart.
+     *  - Does nothing if cart is locked.
+     *
+     * @api
+     *
+     * @param \Generated\Shared\Transfer\CartChangeTransfer $cartChangeTransfer
+     *
+     * @return \Generated\Shared\Transfer\QuoteResponseTransfer
+     */
+    public function addToCart(CartChangeTransfer $cartChangeTransfer): QuoteResponseTransfer;
+
+    /**
+     * Specification:
+     *  - Resolve quote storage strategy which implements \Spryker\Client\CartExtension\Dependency\Plugin\QuoteStorageStrategyPluginInterface.
+     *  - Default quote storage strategy \Spryker\Client\Cart\Plugin\SessionQuoteStorageStrategyPlugin.
+     *  - Uses quote storage strategy.
+     *  - Decreases quantity for items using the provided quantities.
+     *  - Removes items from cart that reach 0 quantity.
+     *  - Does nothing if cart is locked.
+     *
+     * @api
+     *
+     * @param \Generated\Shared\Transfer\CartChangeTransfer $cartChangeTransfer
+     *
+     * @return \Generated\Shared\Transfer\QuoteResponseTransfer
+     */
+    public function removeFromCart(CartChangeTransfer $cartChangeTransfer): QuoteResponseTransfer;
+
+    /**
+     * Specification:
+     *  - Resolve quote storage strategy which implements \Spryker\Client\CartExtension\Dependency\Plugin\QuoteStorageStrategyPluginInterface.
+     *  - Default quote storage strategy \Spryker\Client\Cart\Plugin\SessionQuoteStorageStrategyPlugin.
+     *  - Uses quote storage strategy.
+     *  - Updates item quantity to the provided quantities.
+     *  - Does nothing if cart is locked.
+     *
+     * @api
+     *
+     * @param \Generated\Shared\Transfer\CartChangeTransfer $cartChangeTransfer
+     *
+     * @return \Generated\Shared\Transfer\QuoteResponseTransfer
+     */
+    public function updateQuantity(CartChangeTransfer $cartChangeTransfer): QuoteResponseTransfer;
+
+    /**
+     * Specification:
+     *  - Resolve quote storage strategy which implements \Spryker\Client\CartExtension\Dependency\Plugin\QuoteStorageStrategyPluginInterface.
+     *  - Default quote storage strategy \Spryker\Client\Cart\Plugin\SessionQuoteStorageStrategyPlugin.
      *  - Decrease item quantity using quote storage strategy.
      *  - Does nothing if cart is locked.
      *

--- a/src/Spryker/Client/Cart/CartFactory.php
+++ b/src/Spryker/Client/Cart/CartFactory.php
@@ -9,6 +9,8 @@ namespace Spryker\Client\Cart;
 
 use Spryker\Client\Cart\CartChangeRequestExpander\CartChangeRequestExpander;
 use Spryker\Client\Cart\Dependency\Client\CartToMessengerClientInterface;
+use Spryker\Client\Cart\Operation\CartOperation;
+use Spryker\Client\Cart\Operation\CartOperationInterface;
 use Spryker\Client\Cart\QuoteStorageStrategy\QuoteStorageStrategyProvider;
 use Spryker\Client\Cart\QuoteStorageStrategy\QuoteStorageStrategyProxy;
 use Spryker\Client\Cart\QuoteStorageStrategy\QuoteStorageStrategyProxyInterface;
@@ -17,6 +19,19 @@ use Spryker\Client\Kernel\AbstractFactory;
 
 class CartFactory extends AbstractFactory
 {
+    /**
+     * @return \Spryker\Client\Cart\Operation\CartOperationInterface
+     */
+    public function createCartOperation(): CartOperationInterface
+    {
+        return new CartOperation(
+            $this->getQuoteClient(),
+            $this->createZedStub(),
+            $this->createCartChangeRequestExpander(),
+            $this->getQuoteItemFinderPlugin()
+        );
+    }
+
     /**
      * @return \Spryker\Client\Cart\Dependency\Client\CartToQuoteInterface
      */

--- a/src/Spryker/Client/Cart/Operation/CartOperation.php
+++ b/src/Spryker/Client/Cart/Operation/CartOperation.php
@@ -1,0 +1,251 @@
+<?php
+
+/**
+ * Copyright © 2016-present Spryker Systems GmbH. All rights reserved.
+ * Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
+ */
+
+namespace Spryker\Client\Cart\Operation;
+
+use ArrayObject;
+use Generated\Shared\Transfer\CartChangeTransfer;
+use Generated\Shared\Transfer\ItemTransfer;
+use Generated\Shared\Transfer\QuoteResponseTransfer;
+use Spryker\Client\Cart\CartChangeRequestExpander\CartChangeRequestExpanderInterface;
+use Spryker\Client\Cart\Dependency\Client\CartToQuoteInterface;
+use Spryker\Client\Cart\Zed\CartStubInterface;
+use Spryker\Client\CartExtension\Dependency\Plugin\QuoteItemFinderPluginInterface;
+
+class CartOperation implements CartOperationInterface
+{
+    /**
+     * @var \Spryker\Client\Cart\Dependency\Client\CartToQuoteInterface
+     */
+    protected $quoteClient;
+
+    /**
+     * @var \Spryker\Client\Cart\Zed\CartStubInterface
+     */
+    protected $cartStub;
+
+    /**
+     * @var \Spryker\Client\Cart\CartChangeRequestExpander\CartChangeRequestExpanderInterface
+     */
+    protected $cartChangeRequestExpander;
+
+    /**
+     * @var \Spryker\Client\CartExtension\Dependency\Plugin\QuoteItemFinderPluginInterface
+     */
+    protected $quoteItemFinderPlugin;
+
+    /**
+     * @param \Spryker\Client\Cart\Dependency\Client\CartToQuoteInterface $quoteClient
+     * @param \Spryker\Client\Cart\Zed\CartStubInterface $cartStub
+     * @param \Spryker\Client\Cart\CartChangeRequestExpander\CartChangeRequestExpanderInterface $cartChangeRequestExpander
+     * @param \Spryker\Client\CartExtension\Dependency\Plugin\QuoteItemFinderPluginInterface $quoteItemFinderPlugin
+     */
+    public function __construct(
+        CartToQuoteInterface $quoteClient,
+        CartStubInterface $cartStub,
+        CartChangeRequestExpanderInterface $cartChangeRequestExpander,
+        QuoteItemFinderPluginInterface $quoteItemFinderPlugin
+    ) {
+        $this->quoteClient = $quoteClient;
+        $this->cartStub = $cartStub;
+        $this->cartChangeRequestExpander = $cartChangeRequestExpander;
+        $this->quoteItemFinderPlugin = $quoteItemFinderPlugin;
+    }
+
+    /**
+     * @param \Generated\Shared\Transfer\CartChangeTransfer $cartChangeTransfer
+     *
+     * @return \Generated\Shared\Transfer\QuoteResponseTransfer
+     */
+    public function addToCart(CartChangeTransfer $cartChangeTransfer): QuoteResponseTransfer
+    {
+        $cartChangeTransfer->setQuote($this->quoteClient->getQuote());
+        $cartChangeTransfer = $this->cartChangeRequestExpander->addItemsRequestExpand($cartChangeTransfer);
+
+        $quoteResponseTransfer = $this->cartStub->addToCart($cartChangeTransfer);
+
+        if ($quoteResponseTransfer->getIsSuccessful()) {
+            $this->quoteClient->setQuote($quoteResponseTransfer->getQuoteTransfer());
+        }
+
+        return $quoteResponseTransfer;
+    }
+
+    /**
+     * @param \Generated\Shared\Transfer\CartChangeTransfer $cartChangeTransfer
+     *
+     * @return \Generated\Shared\Transfer\QuoteResponseTransfer
+     */
+    public function removeFromCart(CartChangeTransfer $cartChangeTransfer): QuoteResponseTransfer
+    {
+        $cartChangeTransfer->setQuote($this->quoteClient->getQuote());
+        $cartChangeTransfer = $this->cartChangeRequestExpander->removeItemRequestExpand($cartChangeTransfer);
+
+        $quoteResponseTransfer = $this->cartStub->removeFromCart($cartChangeTransfer);
+
+        if ($quoteResponseTransfer->getIsSuccessful()) {
+            $this->quoteClient->setQuote($quoteResponseTransfer->getQuoteTransfer());
+        }
+
+        return $quoteResponseTransfer;
+    }
+
+    /**
+     * @param \Generated\Shared\Transfer\CartChangeTransfer $cartChangeTransfer
+     *
+     * @return \Generated\Shared\Transfer\QuoteResponseTransfer
+     */
+    public function updateQuantity(CartChangeTransfer $cartChangeTransfer): QuoteResponseTransfer
+    {
+        $cartChangeTransferForAdding = $this->prepareCartChangeTransferForAdding($cartChangeTransfer);
+        $cartChangeTransferForRemoval = $this->prepareCartChangeTransferForRemoval($cartChangeTransfer);
+
+        $quoteResponseTransfer = $this->executeUpdateQuantity($cartChangeTransferForAdding, $cartChangeTransferForRemoval);
+
+        if (!$quoteResponseTransfer->getIsSuccessful()) {
+            return (new QuoteResponseTransfer())
+                ->setQuoteTransfer($this->quoteClient->getQuote())
+                ->setIsSuccessful(false);
+        }
+
+        $this->quoteClient->setQuote($quoteResponseTransfer->getQuoteTransfer());
+
+        return $quoteResponseTransfer;
+    }
+
+    /**
+     * @param \Generated\Shared\Transfer\CartChangeTransfer $cartChangeTransferForAdding
+     * @param \Generated\Shared\Transfer\CartChangeTransfer $cartChangeTransferForRemoval
+     *
+     * @return \Generated\Shared\Transfer\QuoteResponseTransfer
+     */
+    protected function executeUpdateQuantity(
+        CartChangeTransfer $cartChangeTransferForAdding,
+        CartChangeTransfer $cartChangeTransferForRemoval
+    ): QuoteResponseTransfer {
+        $quoteResponseTransfer = (new QuoteResponseTransfer())
+            ->setQuoteTransfer($this->quoteClient->getQuote())
+            ->setIsSuccessful(true);
+
+        if (!$cartChangeTransferForAdding->getItems()->count() && !$cartChangeTransferForRemoval->getItems()->count()) {
+            return $quoteResponseTransfer;
+        }
+
+        if ($cartChangeTransferForAdding->getItems()->count()) {
+            $quoteResponseTransfer = $this->cartStub->addToCart($cartChangeTransferForAdding);
+        }
+
+        if ($quoteResponseTransfer->getIsSuccessful() && $cartChangeTransferForRemoval->getItems()->count()) {
+            return $this->cartStub->removeFromCart($cartChangeTransferForRemoval);
+        }
+
+        return $quoteResponseTransfer;
+    }
+
+    /**
+     * @param \Generated\Shared\Transfer\CartChangeTransfer $cartChangeTransfer
+     *
+     * @return \Generated\Shared\Transfer\CartChangeTransfer
+     */
+    protected function prepareCartChangeTransferForAdding(CartChangeTransfer $cartChangeTransfer): CartChangeTransfer
+    {
+        $cartChangeTransferForAdding = $this->createCartChangeTransfer();
+
+        foreach ($cartChangeTransfer->getItems() as $changeItem) {
+            $quoteItem = $this->findItem($changeItem->getSku(), $changeItem->getGroupKey());
+
+            if (!$quoteItem || $changeItem->getQuantity() <= 0) {
+                continue;
+            }
+
+            $delta = $changeItem->getQuantity() - $quoteItem->getQuantity();
+
+            if ($delta <= 0) {
+                continue;
+            }
+
+            $changeItemTransfer = clone $quoteItem;
+            $changeItemTransfer->setQuantity($delta);
+
+            $cartChangeTransferForAdding->addItem($changeItemTransfer);
+        }
+
+        if (!$cartChangeTransferForAdding->getItems()->count()) {
+            return $cartChangeTransferForAdding;
+        }
+
+        return $this->cartChangeRequestExpander->addItemsRequestExpand($cartChangeTransferForAdding);
+    }
+
+    /**
+     * @param \Generated\Shared\Transfer\CartChangeTransfer $cartChangeTransfer
+     *
+     * @return \Generated\Shared\Transfer\CartChangeTransfer
+     */
+    protected function prepareCartChangeTransferForRemoval(CartChangeTransfer $cartChangeTransfer): CartChangeTransfer
+    {
+        $cartChangeTransferForRemoval = $this->createCartChangeTransfer();
+
+        foreach ($cartChangeTransfer->getItems() as $changeItem) {
+            $quoteItem = $this->findItem($changeItem->getSku(), $changeItem->getGroupKey());
+
+            if (!$quoteItem) {
+                continue;
+            }
+
+            if ($changeItem->getQuantity() === 0) {
+                $cartChangeTransferForRemoval->addItem($quoteItem);
+                continue;
+            }
+
+            $delta = $changeItem->getQuantity() - $quoteItem->getQuantity();
+
+            if ($delta >= 0) {
+                continue;
+            }
+
+            $changeItemTransfer = clone $quoteItem;
+            $changeItemTransfer->setQuantity(abs($delta));
+
+            $cartChangeTransferForRemoval->addItem($changeItemTransfer);
+        }
+
+        if (!$cartChangeTransferForRemoval->getItems()->count()) {
+            return $cartChangeTransferForRemoval;
+        }
+
+        return $this->cartChangeRequestExpander->removeItemRequestExpand($cartChangeTransferForRemoval);
+    }
+
+    /**
+     * @return \Generated\Shared\Transfer\CartChangeTransfer
+     */
+    protected function createCartChangeTransfer(): CartChangeTransfer
+    {
+        $quoteTransfer = $this->quoteClient->getQuote();
+
+        if (count($quoteTransfer->getItems()) === 0) {
+            $quoteTransfer->setItems(new ArrayObject());
+        }
+
+        return (new CartChangeTransfer())
+            ->setQuote($quoteTransfer);
+    }
+
+    /**
+     * @param string $sku
+     * @param string|null $groupKey
+     *
+     * @return \Generated\Shared\Transfer\ItemTransfer|null
+     */
+    protected function findItem($sku, $groupKey = null): ?ItemTransfer
+    {
+        $quoteTransfer = $this->quoteClient->getQuote();
+
+        return $this->quoteItemFinderPlugin->findItem($quoteTransfer, $sku, $groupKey);
+    }
+}

--- a/src/Spryker/Client/Cart/Operation/CartOperationInterface.php
+++ b/src/Spryker/Client/Cart/Operation/CartOperationInterface.php
@@ -1,0 +1,35 @@
+<?php
+
+/**
+ * Copyright © 2016-present Spryker Systems GmbH. All rights reserved.
+ * Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
+ */
+
+namespace Spryker\Client\Cart\Operation;
+
+use Generated\Shared\Transfer\CartChangeTransfer;
+use Generated\Shared\Transfer\QuoteResponseTransfer;
+
+interface CartOperationInterface
+{
+    /**
+     * @param \Generated\Shared\Transfer\CartChangeTransfer $cartChangeTransfer
+     *
+     * @return \Generated\Shared\Transfer\QuoteResponseTransfer
+     */
+    public function addToCart(CartChangeTransfer $cartChangeTransfer): QuoteResponseTransfer;
+
+    /**
+     * @param \Generated\Shared\Transfer\CartChangeTransfer $cartChangeTransfer
+     *
+     * @return \Generated\Shared\Transfer\QuoteResponseTransfer
+     */
+    public function removeFromCart(CartChangeTransfer $cartChangeTransfer): QuoteResponseTransfer;
+
+    /**
+     * @param \Generated\Shared\Transfer\CartChangeTransfer $cartChangeTransfer
+     *
+     * @return \Generated\Shared\Transfer\QuoteResponseTransfer
+     */
+    public function updateQuantity(CartChangeTransfer $cartChangeTransfer): QuoteResponseTransfer;
+}

--- a/src/Spryker/Client/Cart/Plugin/SessionQuoteStorageStrategyPlugin.php
+++ b/src/Spryker/Client/Cart/Plugin/SessionQuoteStorageStrategyPlugin.php
@@ -13,6 +13,7 @@ use Generated\Shared\Transfer\CurrencyTransfer;
 use Generated\Shared\Transfer\ItemTransfer;
 use Generated\Shared\Transfer\QuoteResponseTransfer;
 use Generated\Shared\Transfer\QuoteTransfer;
+use Spryker\Client\CartExtension\Dependency\Plugin\CartOperationQuoteStorageStrategyPluginInterface;
 use Spryker\Client\CartExtension\Dependency\Plugin\QuoteResetLockQuoteStorageStrategyPluginInterface;
 use Spryker\Client\CartExtension\Dependency\Plugin\QuoteStorageStrategyPluginInterface;
 use Spryker\Client\Kernel\AbstractPlugin;
@@ -22,7 +23,7 @@ use Spryker\Shared\Quote\QuoteConfig;
  * @method \Spryker\Client\Cart\CartClientInterface getClient()
  * @method \Spryker\Client\Cart\CartFactory getFactory()
  */
-class SessionQuoteStorageStrategyPlugin extends AbstractPlugin implements QuoteStorageStrategyPluginInterface, QuoteResetLockQuoteStorageStrategyPluginInterface
+class SessionQuoteStorageStrategyPlugin extends AbstractPlugin implements QuoteStorageStrategyPluginInterface, QuoteResetLockQuoteStorageStrategyPluginInterface, CartOperationQuoteStorageStrategyPluginInterface
 {
     /**
      * @return string
@@ -204,6 +205,60 @@ class SessionQuoteStorageStrategyPlugin extends AbstractPlugin implements QuoteS
         }
 
         return $this->increaseItemQuantity($sku, $groupKey, $delta);
+    }
+
+    /**
+     * Specification:
+     * - Makes zed request.
+     * - Adds items to quote.
+     * - Stores quote in session internally after success zed request.
+     * - Returns response with updated quote.
+     *
+     * @param \Generated\Shared\Transfer\CartChangeTransfer $cartChangeTransfer
+     *
+     * @return \Generated\Shared\Transfer\QuoteResponseTransfer
+     */
+    public function addToCart(CartChangeTransfer $cartChangeTransfer): QuoteResponseTransfer
+    {
+        return $this->getFactory()
+            ->createCartOperation()
+            ->addToCart($cartChangeTransfer);
+    }
+
+    /**
+     * Specification:
+     * - Makes zed request.
+     * - Adds items to quote.
+     * - Stores quote in session internally after success zed request.
+     * - Returns response with updated quote.
+     *
+     * @param \Generated\Shared\Transfer\CartChangeTransfer $cartChangeTransfer
+     *
+     * @return \Generated\Shared\Transfer\QuoteResponseTransfer
+     */
+    public function removeFromCart(CartChangeTransfer $cartChangeTransfer): QuoteResponseTransfer
+    {
+        return $this->getFactory()
+            ->createCartOperation()
+            ->removeFromCart($cartChangeTransfer);
+    }
+
+    /**
+     * Specification:
+     * - Makes zed request.
+     * - Updates quantity for given items.
+     * - Stores quote in session internally after successful zed request.
+     * - Returns response with updated quote.
+     *
+     * @param \Generated\Shared\Transfer\CartChangeTransfer $cartChangeTransfer
+     *
+     * @return \Generated\Shared\Transfer\QuoteResponseTransfer
+     */
+    public function updateQuantity(CartChangeTransfer $cartChangeTransfer): QuoteResponseTransfer
+    {
+        return $this->getFactory()
+            ->createCartOperation()
+            ->updateQuantity($cartChangeTransfer);
     }
 
     /**

--- a/src/Spryker/Client/Cart/QuoteStorageStrategy/QuoteStorageStrategyProxy.php
+++ b/src/Spryker/Client/Cart/QuoteStorageStrategy/QuoteStorageStrategyProxy.php
@@ -16,6 +16,7 @@ use Generated\Shared\Transfer\QuoteTransfer;
 use Spryker\Client\Cart\Dependency\Client\CartToMessengerClientInterface;
 use Spryker\Client\Cart\Dependency\Client\CartToQuoteInterface;
 use Spryker\Client\Cart\Exception\QuoteStorageStrategyPluginNotFound;
+use Spryker\Client\CartExtension\Dependency\Plugin\CartOperationQuoteStorageStrategyPluginInterface;
 use Spryker\Client\CartExtension\Dependency\Plugin\QuoteResetLockQuoteStorageStrategyPluginInterface;
 use Spryker\Client\CartExtension\Dependency\Plugin\QuoteStorageStrategyPluginInterface;
 
@@ -151,6 +152,78 @@ class QuoteStorageStrategyProxy implements QuoteStorageStrategyProxyInterface
         }
 
         return $this->quoteStorageStrategy->changeItemQuantity($sku, $groupKey, $quantity);
+    }
+
+    /**
+     * @param \Generated\Shared\Transfer\CartChangeTransfer $cartChangeTransfer
+     *
+     * @throws \Spryker\Client\Cart\Exception\QuoteStorageStrategyPluginNotFound
+     *
+     * @return \Generated\Shared\Transfer\QuoteResponseTransfer
+     */
+    public function addToCart(CartChangeTransfer $cartChangeTransfer): QuoteResponseTransfer
+    {
+        if ($this->isQuoteLocked()) {
+            $this->addPermissionFailedMessage();
+
+            return $this->createNotSuccessfulQuoteResponseTransfer();
+        }
+
+        if (!$this->quoteStorageStrategy instanceof CartOperationQuoteStorageStrategyPluginInterface) {
+            throw new QuoteStorageStrategyPluginNotFound(
+                'Quote storage strategy should implement CartOperationQuoteStorageStrategyPluginInterface in order to use `addToCart` functionality.'
+            );
+        }
+
+        return $this->quoteStorageStrategy->addToCart($cartChangeTransfer);
+    }
+
+    /**
+     * @param \Generated\Shared\Transfer\CartChangeTransfer $cartChangeTransfer
+     *
+     * @throws \Spryker\Client\Cart\Exception\QuoteStorageStrategyPluginNotFound
+     *
+     * @return \Generated\Shared\Transfer\QuoteResponseTransfer
+     */
+    public function removeFromCart(CartChangeTransfer $cartChangeTransfer): QuoteResponseTransfer
+    {
+        if ($this->isQuoteLocked()) {
+            $this->addPermissionFailedMessage();
+
+            return $this->createNotSuccessfulQuoteResponseTransfer();
+        }
+
+        if (!$this->quoteStorageStrategy instanceof CartOperationQuoteStorageStrategyPluginInterface) {
+            throw new QuoteStorageStrategyPluginNotFound(
+                'Quote storage strategy should implement CartOperationQuoteStorageStrategyPluginInterface in order to use `removeFromCart` functionality.'
+            );
+        }
+
+        return $this->quoteStorageStrategy->removeFromCart($cartChangeTransfer);
+    }
+
+    /**
+     * @param \Generated\Shared\Transfer\CartChangeTransfer $cartChangeTransfer
+     *
+     * @throws \Spryker\Client\Cart\Exception\QuoteStorageStrategyPluginNotFound
+     *
+     * @return \Generated\Shared\Transfer\QuoteResponseTransfer
+     */
+    public function updateQuantity(CartChangeTransfer $cartChangeTransfer): QuoteResponseTransfer
+    {
+        if ($this->isQuoteLocked()) {
+            $this->addPermissionFailedMessage();
+
+            return $this->createNotSuccessfulQuoteResponseTransfer();
+        }
+
+        if (!$this->quoteStorageStrategy instanceof CartOperationQuoteStorageStrategyPluginInterface) {
+            throw new QuoteStorageStrategyPluginNotFound(
+                'Quote storage strategy should implement CartOperationQuoteStorageStrategyPluginInterface in order to use `updateQuantity` functionality.'
+            );
+        }
+
+        return $this->quoteStorageStrategy->updateQuantity($cartChangeTransfer);
     }
 
     /**

--- a/src/Spryker/Client/Cart/QuoteStorageStrategy/QuoteStorageStrategyProxyInterface.php
+++ b/src/Spryker/Client/Cart/QuoteStorageStrategy/QuoteStorageStrategyProxyInterface.php
@@ -7,9 +7,10 @@
 
 namespace Spryker\Client\Cart\QuoteStorageStrategy;
 
+use Spryker\Client\CartExtension\Dependency\Plugin\CartOperationQuoteStorageStrategyPluginInterface;
 use Spryker\Client\CartExtension\Dependency\Plugin\QuoteResetLockQuoteStorageStrategyPluginInterface;
 use Spryker\Client\CartExtension\Dependency\Plugin\QuoteStorageStrategyPluginInterface;
 
-interface QuoteStorageStrategyProxyInterface extends QuoteStorageStrategyPluginInterface, QuoteResetLockQuoteStorageStrategyPluginInterface
+interface QuoteStorageStrategyProxyInterface extends QuoteStorageStrategyPluginInterface, QuoteResetLockQuoteStorageStrategyPluginInterface, CartOperationQuoteStorageStrategyPluginInterface
 {
 }

--- a/src/Spryker/Client/Cart/Zed/CartStub.php
+++ b/src/Spryker/Client/Cart/Zed/CartStub.php
@@ -42,6 +42,21 @@ class CartStub extends ZedRequestStub implements CartStubInterface
     }
 
     /**
+     * @uses \Spryker\Zed\Cart\Communication\Controller\GatewayController::addToCartAction()
+     *
+     * @param \Generated\Shared\Transfer\CartChangeTransfer $cartChangeTransfer
+     *
+     * @return \Generated\Shared\Transfer\QuoteResponseTransfer
+     */
+    public function addToCart(CartChangeTransfer $cartChangeTransfer): QuoteResponseTransfer
+    {
+        /** @var \Generated\Shared\Transfer\QuoteResponseTransfer $quoteResponseTransfer */
+        $quoteResponseTransfer = $this->zedStub->call('/cart/gateway/add-to-cart', $cartChangeTransfer);
+
+        return $quoteResponseTransfer;
+    }
+
+    /**
      * @param \Generated\Shared\Transfer\CartChangeTransfer $changeTransfer
      *
      * @return \Generated\Shared\Transfer\QuoteTransfer
@@ -52,6 +67,21 @@ class CartStub extends ZedRequestStub implements CartStubInterface
         $quoteTransfer = $this->zedStub->call('/cart/gateway/remove-item', $changeTransfer);
 
         return $quoteTransfer;
+    }
+
+    /**
+     * @uses \Spryker\Zed\Cart\Communication\Controller\GatewayController::removeFromCartAction()
+     *
+     * @param \Generated\Shared\Transfer\CartChangeTransfer $cartChangeTransfer
+     *
+     * @return \Generated\Shared\Transfer\QuoteResponseTransfer
+     */
+    public function removeFromCart(CartChangeTransfer $cartChangeTransfer): QuoteResponseTransfer
+    {
+        /** @var \Generated\Shared\Transfer\QuoteResponseTransfer $quoteResponseTransfer */
+        $quoteResponseTransfer = $this->zedStub->call('/cart/gateway/remove-from-cart', $cartChangeTransfer);
+
+        return $quoteResponseTransfer;
     }
 
     /**

--- a/src/Spryker/Client/Cart/Zed/CartStubInterface.php
+++ b/src/Spryker/Client/Cart/Zed/CartStubInterface.php
@@ -31,9 +31,23 @@ interface CartStubInterface
     /**
      * @param \Generated\Shared\Transfer\CartChangeTransfer $cartChangeTransfer
      *
+     * @return \Generated\Shared\Transfer\QuoteResponseTransfer
+     */
+    public function addToCart(CartChangeTransfer $cartChangeTransfer): QuoteResponseTransfer;
+
+    /**
+     * @param \Generated\Shared\Transfer\CartChangeTransfer $cartChangeTransfer
+     *
      * @return \Generated\Shared\Transfer\QuoteTransfer
      */
     public function removeItem(CartChangeTransfer $cartChangeTransfer);
+
+    /**
+     * @param \Generated\Shared\Transfer\CartChangeTransfer $cartChangeTransfer
+     *
+     * @return \Generated\Shared\Transfer\QuoteResponseTransfer
+     */
+    public function removeFromCart(CartChangeTransfer $cartChangeTransfer): QuoteResponseTransfer;
 
     /**
      * @param \Generated\Shared\Transfer\QuoteTransfer $quoteTransfer

--- a/src/Spryker/Zed/Cart/Business/CartBusinessFactory.php
+++ b/src/Spryker/Zed/Cart/Business/CartBusinessFactory.php
@@ -159,7 +159,7 @@ class CartBusinessFactory extends AbstractBusinessFactory
     }
 
     /**
-     * @return \Spryker\Zed\Cart\Dependency\PostSavePluginInterface[]
+     * @return \Spryker\Zed\CartExtension\Dependency\Plugin\CartOperationPostSavePluginInterface[]
      */
     protected function getPostSavePlugins()
     {

--- a/src/Spryker/Zed/Cart/Business/CartFacade.php
+++ b/src/Spryker/Zed/Cart/Business/CartFacade.php
@@ -51,6 +51,20 @@ class CartFacade extends AbstractFacade implements CartFacadeInterface
      *
      * @param \Generated\Shared\Transfer\CartChangeTransfer $cartChangeTransfer
      *
+     * @return \Generated\Shared\Transfer\QuoteResponseTransfer
+     */
+    public function addToCart(CartChangeTransfer $cartChangeTransfer): QuoteResponseTransfer
+    {
+        return $this->getFactory()->createCartOperation()->addToCart($cartChangeTransfer);
+    }
+
+    /**
+     * {@inheritdoc}
+     *
+     * @api
+     *
+     * @param \Generated\Shared\Transfer\CartChangeTransfer $cartChangeTransfer
+     *
      * @return \Generated\Shared\Transfer\QuoteTransfer
      */
     public function remove(CartChangeTransfer $cartChangeTransfer)
@@ -84,6 +98,20 @@ class CartFacade extends AbstractFacade implements CartFacadeInterface
     public function validateQuote(QuoteTransfer $quoteTransfer): QuoteResponseTransfer
     {
         return $this->getFactory()->createQuoteValidator()->validate($quoteTransfer);
+    }
+
+    /**
+     * {@inheritdoc}
+     *
+     * @api
+     *
+     * @param \Generated\Shared\Transfer\CartChangeTransfer $cartChangeTransfer
+     *
+     * @return \Generated\Shared\Transfer\QuoteResponseTransfer
+     */
+    public function removeFromCart(CartChangeTransfer $cartChangeTransfer): QuoteResponseTransfer
+    {
+        return $this->getFactory()->createCartOperation()->removeFromCart($cartChangeTransfer);
     }
 
     /**

--- a/src/Spryker/Zed/Cart/Business/CartFacadeInterface.php
+++ b/src/Spryker/Zed/Cart/Business/CartFacadeInterface.php
@@ -63,6 +63,27 @@ interface CartFacadeInterface
 
     /**
      * Specification:
+     *  - Adds item(s) to the quote. Each item gets additional information (e.g. price).
+     *  - Does nothing if cart is locked.
+     *  - Runs cart pre check plugins.
+     *  - For each new item runs the item expander plugins (requires a SKU for each new item).
+     *  - Adds new item(s) to quote (requires, but not limited, a quantity > 0 for each new item).
+     *  - Groups items in quote.
+     *  - Recalculates quote.
+     *  - Adds success message to messenger.
+     *  - Returns QuoteResponse with updated quote if quote is not locked.
+     *  - In case of error adds messenger error message and returns QuoteResponse with unchanged QuoteTransfer and errors.
+     *
+     * @api
+     *
+     * @param \Generated\Shared\Transfer\CartChangeTransfer $cartChangeTransfer
+     *
+     * @return \Generated\Shared\Transfer\QuoteResponseTransfer
+     */
+    public function addToCart(CartChangeTransfer $cartChangeTransfer): QuoteResponseTransfer;
+
+    /**
+     * Specification:
      *  - For each new item run the item expander plugins (requires a SKU for each new item)
      *  - Decreases the given quantity for the given item(s) from the quote
      *  - Recalculate quote (-> Calculation)
@@ -76,6 +97,24 @@ interface CartFacadeInterface
      * @return \Generated\Shared\Transfer\QuoteTransfer
      */
     public function remove(CartChangeTransfer $cartChangeTransfer);
+
+    /**
+     * Specification:
+     *  - For each item runs the item expander plugins (requires a SKU for each new item).
+     *  - Decreases the given quantity for the given item(s) from the quote.
+     *  - Recalculates quote (-> Calculation).
+     *  - Adds success message to messenger (-> Messenger).
+     *  - Returns updated quote.
+     *  - Returns QuoteResponse with updated quote if quote is not locked.
+     *  - In case of error adds messenger error message and returns QuoteResponse with unchanged QuoteTransfer and errors.
+     *
+     * @api
+     *
+     * @param \Generated\Shared\Transfer\CartChangeTransfer $cartChangeTransfer
+     *
+     * @return \Generated\Shared\Transfer\QuoteResponseTransfer
+     */
+    public function removeFromCart(CartChangeTransfer $cartChangeTransfer): QuoteResponseTransfer;
 
     /**
      * Specification:

--- a/src/Spryker/Zed/Cart/Business/Model/OperationInterface.php
+++ b/src/Spryker/Zed/Cart/Business/Model/OperationInterface.php
@@ -8,6 +8,7 @@
 namespace Spryker\Zed\Cart\Business\Model;
 
 use Generated\Shared\Transfer\CartChangeTransfer;
+use Generated\Shared\Transfer\QuoteResponseTransfer;
 use Generated\Shared\Transfer\QuoteTransfer;
 
 interface OperationInterface
@@ -29,9 +30,23 @@ interface OperationInterface
     /**
      * @param \Generated\Shared\Transfer\CartChangeTransfer $cartChangeTransfer
      *
+     * @return \Generated\Shared\Transfer\QuoteResponseTransfer
+     */
+    public function addToCart(CartChangeTransfer $cartChangeTransfer): QuoteResponseTransfer;
+
+    /**
+     * @param \Generated\Shared\Transfer\CartChangeTransfer $cartChangeTransfer
+     *
      * @return \Generated\Shared\Transfer\QuoteTransfer
      */
     public function remove(CartChangeTransfer $cartChangeTransfer);
+
+    /**
+     * @param \Generated\Shared\Transfer\CartChangeTransfer $cartChangeTransfer
+     *
+     * @return \Generated\Shared\Transfer\QuoteResponseTransfer
+     */
+    public function removeFromCart(CartChangeTransfer $cartChangeTransfer): QuoteResponseTransfer;
 
     /**
      * @param \Generated\Shared\Transfer\QuoteTransfer $quoteTransfer

--- a/src/Spryker/Zed/Cart/CartDependencyProvider.php
+++ b/src/Spryker/Zed/Cart/CartDependencyProvider.php
@@ -286,7 +286,7 @@ class CartDependencyProvider extends AbstractBundleDependencyProvider
     /**
      * @param \Spryker\Zed\Kernel\Container $container
      *
-     * @return \Spryker\Zed\Cart\Dependency\PostSavePluginInterface[]
+     * @return \Spryker\Zed\CartExtension\Dependency\Plugin\CartOperationPostSavePluginInterface[]
      */
     protected function getPostSavePlugins(Container $container)
     {

--- a/src/Spryker/Zed/Cart/Communication/Controller/GatewayController.php
+++ b/src/Spryker/Zed/Cart/Communication/Controller/GatewayController.php
@@ -40,11 +40,31 @@ class GatewayController extends AbstractGatewayController
     /**
      * @param \Generated\Shared\Transfer\CartChangeTransfer $cartChangeTransfer
      *
+     * @return \Generated\Shared\Transfer\QuoteResponseTransfer
+     */
+    public function addToCartAction(CartChangeTransfer $cartChangeTransfer): QuoteResponseTransfer
+    {
+        return $this->getFacade()->addToCart($cartChangeTransfer);
+    }
+
+    /**
+     * @param \Generated\Shared\Transfer\CartChangeTransfer $cartChangeTransfer
+     *
      * @return \Generated\Shared\Transfer\QuoteTransfer
      */
     public function removeItemAction(CartChangeTransfer $cartChangeTransfer)
     {
         return $this->getFacade()->remove($cartChangeTransfer);
+    }
+
+    /**
+     * @param \Generated\Shared\Transfer\CartChangeTransfer $cartChangeTransfer
+     *
+     * @return \Generated\Shared\Transfer\QuoteResponseTransfer
+     */
+    public function removeFromCartAction(CartChangeTransfer $cartChangeTransfer): QuoteResponseTransfer
+    {
+        return $this->getFacade()->removeFromCart($cartChangeTransfer);
     }
 
     /**

--- a/src/Spryker/Zed/Cart/Dependency/PostSavePluginInterface.php
+++ b/src/Spryker/Zed/Cart/Dependency/PostSavePluginInterface.php
@@ -7,17 +7,11 @@
 
 namespace Spryker\Zed\Cart\Dependency;
 
-use Generated\Shared\Transfer\QuoteTransfer;
+use Spryker\Zed\CartExtension\Dependency\Plugin\CartOperationPostSavePluginInterface as SprykerCartOperationPostSavePluginInterface;
 
-interface PostSavePluginInterface
+/**
+ * @deprecated Use \Spryker\Zed\CartExtension\Dependency\Plugin\CartOperationPostSavePluginInterface instead.
+ */
+interface PostSavePluginInterface extends SprykerCartOperationPostSavePluginInterface
 {
-    /**
-     * Specification:
-     *  - This plugin executed after add and remove operations, you will receive modified quote which is ready to store in client side
-     *
-     * @param \Generated\Shared\Transfer\QuoteTransfer $quoteTransfer
-     *
-     * @return \Generated\Shared\Transfer\QuoteTransfer $quoteTransfer
-     */
-    public function postSave(QuoteTransfer $quoteTransfer);
 }

--- a/tests/SprykerTest/Client/Cart/CartClientTest.php
+++ b/tests/SprykerTest/Client/Cart/CartClientTest.php
@@ -311,6 +311,8 @@ class CartClientTest extends Unit
             'addFlashMessagesFromLastZedRequest',
             'addResponseMessagesToMessenger',
             'resetQuoteLock',
+            'addToCart',
+            'removeFromCart',
         ])->getMock();
     }
 }

--- a/tests/SprykerTest/Client/Cart/CartOperationTest.php
+++ b/tests/SprykerTest/Client/Cart/CartOperationTest.php
@@ -1,0 +1,529 @@
+<?php
+
+/**
+ * Copyright © 2016-present Spryker Systems GmbH. All rights reserved.
+ * Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
+ */
+
+namespace SprykerTest\Client\Cart;
+
+use Codeception\Test\Unit;
+use Generated\Shared\Transfer\CartChangeTransfer;
+use Generated\Shared\Transfer\ItemTransfer;
+use Generated\Shared\Transfer\QuoteResponseTransfer;
+use Generated\Shared\Transfer\QuoteTransfer;
+use Spryker\Client\Cart\CartChangeRequestExpander\CartChangeRequestExpander;
+use Spryker\Client\Cart\Dependency\Client\CartToQuoteBridge;
+use Spryker\Client\Cart\Operation\CartOperation;
+use Spryker\Client\Cart\Plugin\SimpleProductQuoteItemFinderPlugin;
+use Spryker\Client\Cart\Zed\CartStub;
+
+/**
+ * Auto-generated group annotations
+ *
+ * @group SprykerTest
+ * @group Client
+ * @group Cart
+ * @group CartOperationTest
+ * Add your own group annotations below this line
+ */
+class CartOperationTest extends Unit
+{
+    protected const FAKE_SKU_1 = 'fake_sku_1';
+    protected const FAKE_SKU_2 = 'fake_sku_2';
+    protected const FAKE_SKU_3 = 'fake_sku_3';
+
+    /**
+     * @return void
+     */
+    public function testAddToCartAddsItemsToExistingCart(): void
+    {
+        // Arrange
+        $originalQuoteTransfer = (new QuoteTransfer())
+            ->addItem((new ItemTransfer())->setQuantity(5)->setSku(static::FAKE_SKU_1))
+            ->addItem((new ItemTransfer())->setQuantity(2)->setSku(static::FAKE_SKU_2));
+
+        $newQuoteTransfer = (new QuoteTransfer())
+            ->addItem((new ItemTransfer())->setQuantity(5)->setSku(static::FAKE_SKU_1))
+            ->addItem((new ItemTransfer())->setQuantity(5)->setSku(static::FAKE_SKU_2))
+            ->addItem((new ItemTransfer())->setQuantity(5)->setSku(static::FAKE_SKU_3));
+
+        $cartChangeTransfer = (new CartChangeTransfer())
+            ->addItem((new ItemTransfer())->setQuantity(3)->setSku(static::FAKE_SKU_2))
+            ->addItem((new ItemTransfer())->setQuantity(5)->setSku(static::FAKE_SKU_3));
+
+        $cartStubMock = $this->createCartStubMock();
+
+        $cartStubMock
+            ->method('addToCart')
+            ->willReturn((new QuoteResponseTransfer())->setIsSuccessful(true)->setQuoteTransfer($newQuoteTransfer));
+
+        $cartOperationMock = $this->createCartOperationMock($originalQuoteTransfer, $cartStubMock);
+
+        // Act
+        $quoteResponseTransfer = $cartOperationMock->addToCart($cartChangeTransfer);
+
+        // Assert
+        $this->assertTrue($quoteResponseTransfer->getIsSuccessful());
+        $this->assertSame($newQuoteTransfer, $quoteResponseTransfer->getQuoteTransfer());
+    }
+
+    /**
+     * @return void
+     */
+    public function testAddToCartAddsItemsToEmptyCart(): void
+    {
+        // Arrange
+        $originalQuoteTransfer = new QuoteTransfer();
+
+        $newQuoteTransfer = (new QuoteTransfer())
+            ->addItem((new ItemTransfer())->setQuantity(3)->setSku(static::FAKE_SKU_1))
+            ->addItem((new ItemTransfer())->setQuantity(1)->setSku(static::FAKE_SKU_2));
+
+        $cartChangeTransfer = (new CartChangeTransfer())
+            ->addItem((new ItemTransfer())->setQuantity(3)->setSku(static::FAKE_SKU_1))
+            ->addItem((new ItemTransfer())->setQuantity(1)->setSku(static::FAKE_SKU_2));
+
+        $cartStubMock = $this->createCartStubMock();
+
+        $cartStubMock
+            ->method('addToCart')
+            ->willReturn((new QuoteResponseTransfer())->setIsSuccessful(true)->setQuoteTransfer($newQuoteTransfer));
+
+        $cartOperationMock = $this->createCartOperationMock($originalQuoteTransfer, $cartStubMock);
+
+        // Act
+        $quoteResponseTransfer = $cartOperationMock->addToCart($cartChangeTransfer);
+
+        // Assert
+        $this->assertTrue($quoteResponseTransfer->getIsSuccessful());
+        $this->assertSame($newQuoteTransfer, $quoteResponseTransfer->getQuoteTransfer());
+    }
+
+    /**
+     * @return void
+     */
+    public function testAddToCartChecksCaseOfUnsuccessfulAddition(): void
+    {
+        // Arrange
+        $originalQuoteTransfer = (new QuoteTransfer())
+            ->addItem((new ItemTransfer())->setQuantity(1)->setSku(static::FAKE_SKU_1))
+            ->addItem((new ItemTransfer())->setQuantity(1)->setSku(static::FAKE_SKU_2));
+
+        $cartChangeTransfer = (new CartChangeTransfer())
+            ->addItem((new ItemTransfer())->setQuantity(1)->setSku(static::FAKE_SKU_1))
+            ->addItem((new ItemTransfer())->setQuantity(1)->setSku(static::FAKE_SKU_2));
+
+        $cartStubMock = $this->createCartStubMock();
+
+        $cartStubMock
+            ->method('addToCart')
+            ->willReturn((new QuoteResponseTransfer())->setIsSuccessful(false)->setQuoteTransfer($originalQuoteTransfer));
+
+        $cartOperationMock = $this->createCartOperationMock($originalQuoteTransfer, $cartStubMock);
+
+        // Act
+        $quoteResponseTransfer = $cartOperationMock->addToCart($cartChangeTransfer);
+
+        // Assert
+        $this->assertFalse($quoteResponseTransfer->getIsSuccessful());
+        $this->assertSame($originalQuoteTransfer, $quoteResponseTransfer->getQuoteTransfer());
+    }
+
+    /**
+     * @return void
+     */
+    public function testRemoveFromCartRemovesItemsFromExistingCart(): void
+    {
+        // Arrange
+        $originalQuoteTransfer = (new QuoteTransfer())
+            ->addItem((new ItemTransfer())->setQuantity(5)->setSku(static::FAKE_SKU_1))
+            ->addItem((new ItemTransfer())->setQuantity(5)->setSku(static::FAKE_SKU_2))
+            ->addItem((new ItemTransfer())->setQuantity(5)->setSku(static::FAKE_SKU_3));
+
+        $newQuoteTransfer = (new QuoteTransfer())
+            ->addItem((new ItemTransfer())->setQuantity(2)->setSku(static::FAKE_SKU_1))
+            ->addItem((new ItemTransfer())->setQuantity(2)->setSku(static::FAKE_SKU_2));
+
+        $cartChangeTransfer = (new CartChangeTransfer())
+            ->addItem((new ItemTransfer())->setQuantity(3)->setSku(static::FAKE_SKU_1))
+            ->addItem((new ItemTransfer())->setQuantity(3)->setSku(static::FAKE_SKU_2));
+
+        $cartStubMock = $this->createCartStubMock();
+
+        $cartStubMock
+            ->method('removeFromCart')
+            ->willReturn((new QuoteResponseTransfer())->setIsSuccessful(true)->setQuoteTransfer($newQuoteTransfer));
+
+        $cartOperationMock = $this->createCartOperationMock($originalQuoteTransfer, $cartStubMock);
+
+        // Act
+        $quoteResponseTransfer = $cartOperationMock->removeFromCart($cartChangeTransfer);
+
+        // Assert
+        $this->assertTrue($quoteResponseTransfer->getIsSuccessful());
+        $this->assertSame($newQuoteTransfer, $quoteResponseTransfer->getQuoteTransfer());
+    }
+
+    /**
+     * @return void
+     */
+    public function testRemoveFromCartChecksCaseOfUnsuccessfulRemoval(): void
+    {
+        // Arrange
+        $originalQuoteTransfer = new QuoteTransfer();
+
+        $cartChangeTransfer = (new CartChangeTransfer())
+            ->addItem((new ItemTransfer())->setQuantity(3)->setSku(static::FAKE_SKU_1))
+            ->addItem((new ItemTransfer())->setQuantity(1)->setSku(static::FAKE_SKU_2));
+
+        $cartStubMock = $this->createCartStubMock();
+
+        $cartStubMock
+            ->method('removeFromCart')
+            ->willReturn((new QuoteResponseTransfer())->setIsSuccessful(false)->setQuoteTransfer($originalQuoteTransfer));
+
+        $cartOperationMock = $this->createCartOperationMock($originalQuoteTransfer, $cartStubMock);
+
+        // Act
+        $quoteResponseTransfer = $cartOperationMock->removeFromCart($cartChangeTransfer);
+
+        // Assert
+        $this->assertFalse($quoteResponseTransfer->getIsSuccessful());
+        $this->assertSame($originalQuoteTransfer, $quoteResponseTransfer->getQuoteTransfer());
+    }
+
+    /**
+     * @return void
+     */
+    public function testUpdateQuantityDecreasesQuantityForProvidedItems(): void
+    {
+        // Arrange
+        $originalQuoteTransfer = (new QuoteTransfer())
+            ->addItem((new ItemTransfer())->setQuantity(5)->setSku(static::FAKE_SKU_1))
+            ->addItem((new ItemTransfer())->setQuantity(5)->setSku(static::FAKE_SKU_2))
+            ->addItem((new ItemTransfer())->setQuantity(5)->setSku(static::FAKE_SKU_3));
+
+        $newQuoteTransfer = (new QuoteTransfer())
+            ->addItem((new ItemTransfer())->setQuantity(2)->setSku(static::FAKE_SKU_1))
+            ->addItem((new ItemTransfer())->setQuantity(1)->setSku(static::FAKE_SKU_2))
+            ->addItem((new ItemTransfer())->setQuantity(5)->setSku(static::FAKE_SKU_3));
+
+        $cartChangeTransfer = (new CartChangeTransfer())
+            ->addItem((new ItemTransfer())->setQuantity(2)->setSku(static::FAKE_SKU_1))
+            ->addItem((new ItemTransfer())->setQuantity(1)->setSku(static::FAKE_SKU_2));
+
+        $cartStubMock = $this->createCartStubMock();
+
+        $cartStubMock
+            ->method('removeFromCart')
+            ->willReturn((new QuoteResponseTransfer())->setIsSuccessful(true)->setQuoteTransfer($newQuoteTransfer));
+
+        $cartOperationMock = $this->createCartOperationMock($originalQuoteTransfer, $cartStubMock);
+
+        // Act
+        $quoteResponseTransfer = $cartOperationMock->updateQuantity($cartChangeTransfer);
+
+        // Assert
+        $this->assertTrue($quoteResponseTransfer->getIsSuccessful());
+        $this->assertSame($newQuoteTransfer, $quoteResponseTransfer->getQuoteTransfer());
+    }
+
+    /**
+     * @return void
+     */
+    public function testUpdateQuantityIncreasesQuantityForProvidedItems(): void
+    {
+        // Arrange
+        $originalQuoteTransfer = (new QuoteTransfer())
+            ->addItem((new ItemTransfer())->setQuantity(5)->setSku(static::FAKE_SKU_1))
+            ->addItem((new ItemTransfer())->setQuantity(5)->setSku(static::FAKE_SKU_2))
+            ->addItem((new ItemTransfer())->setQuantity(5)->setSku(static::FAKE_SKU_3));
+
+        $newQuoteTransfer = (new QuoteTransfer())
+            ->addItem((new ItemTransfer())->setQuantity(7)->setSku(static::FAKE_SKU_1))
+            ->addItem((new ItemTransfer())->setQuantity(10)->setSku(static::FAKE_SKU_2))
+            ->addItem((new ItemTransfer())->setQuantity(5)->setSku(static::FAKE_SKU_3));
+
+        $cartChangeTransfer = (new CartChangeTransfer())
+            ->addItem((new ItemTransfer())->setQuantity(7)->setSku(static::FAKE_SKU_1))
+            ->addItem((new ItemTransfer())->setQuantity(10)->setSku(static::FAKE_SKU_2));
+
+        $cartStubMock = $this->createCartStubMock();
+
+        $cartStubMock
+            ->method('addToCart')
+            ->willReturn((new QuoteResponseTransfer())->setIsSuccessful(true)->setQuoteTransfer($newQuoteTransfer));
+
+        $cartOperationMock = $this->createCartOperationMock($originalQuoteTransfer, $cartStubMock);
+
+        // Act
+        $quoteResponseTransfer = $cartOperationMock->updateQuantity($cartChangeTransfer);
+
+        // Assert
+        $this->assertTrue($quoteResponseTransfer->getIsSuccessful());
+        $this->assertSame($newQuoteTransfer, $quoteResponseTransfer->getQuoteTransfer());
+    }
+
+    /**
+     * @return void
+     */
+    public function testUpdateQuantityChangesQuantityForProvidedItems(): void
+    {
+        // Arrange
+        $originalQuoteTransfer = (new QuoteTransfer())
+            ->addItem((new ItemTransfer())->setQuantity(5)->setSku(static::FAKE_SKU_1))
+            ->addItem((new ItemTransfer())->setQuantity(5)->setSku(static::FAKE_SKU_2))
+            ->addItem((new ItemTransfer())->setQuantity(5)->setSku(static::FAKE_SKU_3));
+
+        $newQuoteTransfer = (new QuoteTransfer())
+            ->addItem((new ItemTransfer())->setQuantity(1)->setSku(static::FAKE_SKU_1))
+            ->addItem((new ItemTransfer())->setQuantity(10)->setSku(static::FAKE_SKU_2))
+            ->addItem((new ItemTransfer())->setQuantity(5)->setSku(static::FAKE_SKU_3));
+
+        $cartChangeTransfer = (new CartChangeTransfer())
+            ->addItem((new ItemTransfer())->setQuantity(1)->setSku(static::FAKE_SKU_1))
+            ->addItem((new ItemTransfer())->setQuantity(10)->setSku(static::FAKE_SKU_2));
+
+        $cartStubMock = $this->createCartStubMock();
+
+        $cartStubMock
+            ->method('addToCart')
+            ->willReturn((new QuoteResponseTransfer())->setIsSuccessful(true)->setQuoteTransfer($newQuoteTransfer));
+
+        $cartStubMock
+            ->method('removeFromCart')
+            ->willReturn((new QuoteResponseTransfer())->setIsSuccessful(true)->setQuoteTransfer($newQuoteTransfer));
+
+        $cartOperationMock = $this->createCartOperationMock($originalQuoteTransfer, $cartStubMock);
+
+        // Act
+        $quoteResponseTransfer = $cartOperationMock->updateQuantity($cartChangeTransfer);
+
+        // Assert
+        $this->assertTrue($quoteResponseTransfer->getIsSuccessful());
+        $this->assertSame($newQuoteTransfer, $quoteResponseTransfer->getQuoteTransfer());
+    }
+
+    /**
+     * @return void
+     */
+    public function testUpdateQuantityChangesQuantityForEmptyCartChangeTransfer(): void
+    {
+        // Arrange
+        $originalQuoteTransfer = (new QuoteTransfer())
+            ->addItem((new ItemTransfer())->setQuantity(5)->setSku(static::FAKE_SKU_1))
+            ->addItem((new ItemTransfer())->setQuantity(5)->setSku(static::FAKE_SKU_2))
+            ->addItem((new ItemTransfer())->setQuantity(5)->setSku(static::FAKE_SKU_3));
+
+        $cartOperationMock = $this->createCartOperationMock($originalQuoteTransfer, $this->createCartStubMock());
+
+        // Act
+        $quoteResponseTransfer = $cartOperationMock->updateQuantity(new CartChangeTransfer());
+
+        // Assert
+        $this->assertTrue($quoteResponseTransfer->getIsSuccessful());
+        $this->assertSame($originalQuoteTransfer, $quoteResponseTransfer->getQuoteTransfer());
+    }
+
+    /**
+     * @return void
+     */
+    public function testUpdateQuantityChangesQuantityForSameCartChangeTransfer(): void
+    {
+        // Arrange
+        $originalQuoteTransfer = (new QuoteTransfer())
+            ->addItem((new ItemTransfer())->setQuantity(5)->setSku(static::FAKE_SKU_1))
+            ->addItem((new ItemTransfer())->setQuantity(5)->setSku(static::FAKE_SKU_2))
+            ->addItem((new ItemTransfer())->setQuantity(5)->setSku(static::FAKE_SKU_3));
+
+        $cartChangeTransfer = (new CartChangeTransfer())
+            ->addItem((new ItemTransfer())->setQuantity(5)->setSku(static::FAKE_SKU_1))
+            ->addItem((new ItemTransfer())->setQuantity(5)->setSku(static::FAKE_SKU_2))
+            ->addItem((new ItemTransfer())->setQuantity(5)->setSku(static::FAKE_SKU_3));
+
+        $cartOperationMock = $this->createCartOperationMock($originalQuoteTransfer, $this->createCartStubMock());
+
+        // Act
+        $quoteResponseTransfer = $cartOperationMock->updateQuantity($cartChangeTransfer);
+
+        // Assert
+        $this->assertTrue($quoteResponseTransfer->getIsSuccessful());
+        $this->assertSame($originalQuoteTransfer, $quoteResponseTransfer->getQuoteTransfer());
+    }
+
+    /**
+     * @return void
+     */
+    public function testUpdateQuantityUpdatesQuantityWithoutIncreasing(): void
+    {
+        // Arrange
+        $originalQuoteTransfer = (new QuoteTransfer())
+            ->addItem((new ItemTransfer())->setQuantity(5)->setSku(static::FAKE_SKU_1))
+            ->addItem((new ItemTransfer())->setQuantity(5)->setSku(static::FAKE_SKU_2))
+            ->addItem((new ItemTransfer())->setQuantity(5)->setSku(static::FAKE_SKU_3));
+
+        $cartChangeTransfer = (new CartChangeTransfer())
+            ->addItem((new ItemTransfer())->setQuantity(1)->setSku(static::FAKE_SKU_1))
+            ->addItem((new ItemTransfer())->setQuantity(10)->setSku(static::FAKE_SKU_2));
+
+        $cartStubMock = $this->createCartStubMock();
+
+        $cartStubMock
+            ->method('addToCart')
+            ->willReturn((new QuoteResponseTransfer())->setIsSuccessful(false)->setQuoteTransfer($originalQuoteTransfer));
+
+        $cartOperationMock = $this->createCartOperationMock($originalQuoteTransfer, $cartStubMock);
+
+        // Act
+        $quoteResponseTransfer = $cartOperationMock->updateQuantity($cartChangeTransfer);
+
+        // Assert
+        $this->assertFalse($quoteResponseTransfer->getIsSuccessful());
+        $this->assertSame($originalQuoteTransfer, $quoteResponseTransfer->getQuoteTransfer());
+    }
+
+    /**
+     * @return void
+     */
+    public function testUpdateQuantityUpdatesQuantityWithoutDecreasing(): void
+    {
+        // Arrange
+        $originalQuoteTransfer = (new QuoteTransfer())
+            ->addItem((new ItemTransfer())->setQuantity(5)->setSku(static::FAKE_SKU_1))
+            ->addItem((new ItemTransfer())->setQuantity(5)->setSku(static::FAKE_SKU_2))
+            ->addItem((new ItemTransfer())->setQuantity(5)->setSku(static::FAKE_SKU_3));
+
+        $newQuoteTransfer = (new QuoteTransfer())
+            ->addItem((new ItemTransfer())->setQuantity(5)->setSku(static::FAKE_SKU_1))
+            ->addItem((new ItemTransfer())->setQuantity(10)->setSku(static::FAKE_SKU_2))
+            ->addItem((new ItemTransfer())->setQuantity(5)->setSku(static::FAKE_SKU_3));
+
+        $cartChangeTransfer = (new CartChangeTransfer())
+            ->addItem((new ItemTransfer())->setQuantity(1)->setSku(static::FAKE_SKU_1))
+            ->addItem((new ItemTransfer())->setQuantity(10)->setSku(static::FAKE_SKU_2));
+
+        $cartStubMock = $this->createCartStubMock();
+
+        $cartStubMock
+            ->method('addToCart')
+            ->willReturn((new QuoteResponseTransfer())->setIsSuccessful(true)->setQuoteTransfer($newQuoteTransfer));
+
+        $cartStubMock
+            ->method('removeFromCart')
+            ->willReturn((new QuoteResponseTransfer())->setIsSuccessful(false)->setQuoteTransfer($newQuoteTransfer));
+
+        $cartOperationMock = $this->createCartOperationMock($originalQuoteTransfer, $cartStubMock);
+
+        // Act
+        $quoteResponseTransfer = $cartOperationMock->updateQuantity($cartChangeTransfer);
+
+        // Assert
+        $this->assertFalse($quoteResponseTransfer->getIsSuccessful());
+        $this->assertSame($originalQuoteTransfer, $quoteResponseTransfer->getQuoteTransfer());
+    }
+
+    /**
+     * @param \Generated\Shared\Transfer\QuoteTransfer $quoteTransfer
+     * @param \PHPUnit\Framework\MockObject\MockObject|\Spryker\Client\Cart\Zed\CartStub $cartStubMock
+     *
+     * @return \PHPUnit\Framework\MockObject\MockObject|\Spryker\Client\Cart\Operation\CartOperation
+     */
+    protected function createCartOperationMock(QuoteTransfer $quoteTransfer, $cartStubMock)
+    {
+        return $this->getMockBuilder(CartOperation::class)
+            ->setConstructorArgs([
+                $this->createQuoteClientMock($quoteTransfer),
+                $cartStubMock,
+                $this->createCartChangeRequestExpanderMock(),
+                $this->createSimpleProductQuoteItemFinderPluginMock(),
+            ])
+            ->setMethods(null)
+            ->getMock();
+    }
+
+    /**
+     * @param \Generated\Shared\Transfer\QuoteTransfer $quoteTransfer
+     *
+     * @return \PHPUnit\Framework\MockObject\MockObject|\Spryker\Client\Cart\Dependency\Client\CartToQuoteBridge
+     */
+    protected function createQuoteClientMock(QuoteTransfer $quoteTransfer)
+    {
+        $quoteClientMock = $this->getMockBuilder(CartToQuoteBridge::class)
+            ->setMethods([
+                'getQuote',
+                'setQuote',
+            ])
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        $quoteClientMock
+            ->method('getQuote')
+            ->willReturn($quoteTransfer);
+
+        $quoteClientMock
+            ->method('setQuote')
+            ->willReturnCallback(function (QuoteTransfer $quoteTransfer) {
+                return $quoteTransfer;
+            });
+
+        return $quoteClientMock;
+    }
+
+    /**
+     * @return \PHPUnit\Framework\MockObject\MockObject|\Spryker\Client\Cart\Zed\CartStub
+     */
+    protected function createCartStubMock()
+    {
+        $cartStubMock = $this->getMockBuilder(CartStub::class)
+            ->setMethods([
+                'addToCart',
+                'removeFromCart',
+            ])
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        return $cartStubMock;
+    }
+
+    /**
+     * @return \PHPUnit\Framework\MockObject\MockObject|\Spryker\Client\Cart\CartChangeRequestExpander\CartChangeRequestExpander
+     */
+    protected function createCartChangeRequestExpanderMock()
+    {
+        $cartChangeRequestExpanderMock = $this
+            ->getMockBuilder(CartChangeRequestExpander::class)
+            ->setMethods([
+                'addItemsRequestExpand',
+                'removeItemRequestExpand',
+            ])
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        $cartChangeRequestExpanderMock
+            ->method('addItemsRequestExpand')
+            ->willReturnCallback(function (CartChangeTransfer $cartChangeTransfer) {
+                return $cartChangeTransfer;
+            });
+
+        $cartChangeRequestExpanderMock
+            ->method('removeItemRequestExpand')
+            ->willReturnCallback(function (CartChangeTransfer $cartChangeTransfer) {
+                return $cartChangeTransfer;
+            });
+
+        return $cartChangeRequestExpanderMock;
+    }
+
+    /**
+     * @return \PHPUnit\Framework\MockObject\MockObject|\Spryker\Client\Cart\Plugin\SimpleProductQuoteItemFinderPlugin
+     */
+    protected function createSimpleProductQuoteItemFinderPluginMock()
+    {
+        return $this
+            ->getMockBuilder(SimpleProductQuoteItemFinderPlugin::class)
+            ->disableOriginalConstructor()
+            ->setMethods(null)
+            ->getMock();
+    }
+}


### PR DESCRIPTION
Branch: backport/ps-10209/cart-5.11.0
Ticket: https://spryker.atlassian.net/browse/PS-10209
Target Version: 5.11.0

#### Release Table

   Module                | Release Type         | Constraint Updates         |
   :--------------------- | :------------------------ | :--------------------- |
   Cart               | minor                 |                       |

#### Release Notes

{skip}

-----------------------------------------

#### Module Cart

##### Change log

Improvements
- Introduced `CartClient::addToCart()`.
- Introduced `CartClient::removeFromCart()`.
- Introduced `CartClient::updateQuantity()`.
- Introduced `CartFacade::removeFromCart()`.
- `SessionQuoteStorageStrategyPlugin` plugin implements `CartOperationQuoteStorageStrategyPluginInterface`.

Deprecations
- Deprecated `PostSavePluginInterface`.
