### PR TITLE
CC-26572 Extension point for replacement strategies

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -6,7 +6,7 @@
   "require": {
     "php": ">=7.1",
     "spryker/calculation": "^4.0.0",
-    "spryker/cart-extension": "^1.9.0 || ^2.5.0 || ^4.1.0",
+    "spryker/cart-extension": "^1.12.0 || ^2.8.0 || ^4.4.0",
     "spryker/kernel": "^3.19.0",
     "spryker/messenger": "^3.1.0",
     "spryker/quote": "^2.10.0",

--- a/src/Spryker/Client/Cart/CartClient.php
+++ b/src/Spryker/Client/Cart/CartClient.php
@@ -260,6 +260,18 @@ class CartClient extends AbstractClient implements CartClientInterface
     }
 
     /**
+     * {@inheritDoc}
+     *
+     * @api
+     *
+     * @return \Generated\Shared\Transfer\QuoteResponseTransfer
+     */
+    public function reloadItemsInQuote(): QuoteResponseTransfer
+    {
+        return $this->getFactory()->createQuoteStorageStrategyProxy()->reloadItems();
+    }
+
+    /**
      * {@inheritdoc}
      *
      * @api

--- a/src/Spryker/Client/Cart/CartClientInterface.php
+++ b/src/Spryker/Client/Cart/CartClientInterface.php
@@ -258,6 +258,19 @@ interface CartClientInterface
 
     /**
      * Specification:
+     * - Resolves quote storage strategy which implements {@link \Spryker\Client\CartExtension\Dependency\Plugin\QuoteStorageStrategyPluginInterface}.
+     * - Uses {@link \Spryker\Client\Cart\Plugin\SessionQuoteStorageStrategyPlugin} as a default strategy.
+     * - Reloads all items in cart as new, recreates all item transfers, reads new prices, options, bundles using quote storage strategy.
+     * - Does nothing if cart is locked.
+     *
+     * @api
+     *
+     * @return \Generated\Shared\Transfer\QuoteResponseTransfer
+     */
+    public function reloadItemsInQuote(): QuoteResponseTransfer;
+
+    /**
+     * Specification:
      *  - Resolve quote storage strategy which implements \Spryker\Client\CartExtension\Dependency\Plugin\QuoteStorageStrategyPluginInterface.
      *  - Default quote storage strategy \Spryker\Client\Cart\Plugin\SessionQuoteStorageStrategyPlugin.
      *  - Reloads quote from storage.

--- a/src/Spryker/Client/Cart/Plugin/SessionQuoteStorageStrategyPlugin.php
+++ b/src/Spryker/Client/Cart/Plugin/SessionQuoteStorageStrategyPlugin.php
@@ -344,14 +344,17 @@ class SessionQuoteStorageStrategyPlugin extends AbstractPlugin implements QuoteS
      *  - Reloads all items in cart anew, it recreates all items transfer, reads new prices, options, bundles.
      *  - Stores quote in session internally after zed request.
      *  - Returns update quote.
+     *  - From next major version (Forward Compatibility): Returns `QuoteResponseTransfer`.
      *
-     * @return void
+     * @return \Generated\Shared\Transfer\QuoteResponseTransfer
      */
     public function reloadItems()
     {
         $quoteTransfer = $this->getQuote();
-        $quoteTransfer = $this->getCartZedStub()->reloadItems($quoteTransfer);
+        $quoteResponseTransfer = $this->getCartZedStub()->reloadItemsInQuote($quoteTransfer);
         $this->getQuoteClient()->setQuote($quoteTransfer);
+
+        return $quoteResponseTransfer;
     }
 
     /**

--- a/src/Spryker/Client/Cart/QuoteStorageStrategy/QuoteStorageStrategyProxy.php
+++ b/src/Spryker/Client/Cart/QuoteStorageStrategy/QuoteStorageStrategyProxy.php
@@ -11,6 +11,7 @@ use ArrayObject;
 use Generated\Shared\Transfer\CartChangeTransfer;
 use Generated\Shared\Transfer\CurrencyTransfer;
 use Generated\Shared\Transfer\ItemTransfer;
+use Generated\Shared\Transfer\QuoteErrorTransfer;
 use Generated\Shared\Transfer\QuoteResponseTransfer;
 use Generated\Shared\Transfer\QuoteTransfer;
 use Spryker\Client\Cart\Dependency\Client\CartToMessengerClientInterface;
@@ -263,17 +264,19 @@ class QuoteStorageStrategyProxy implements QuoteStorageStrategyProxyInterface
     }
 
     /**
-     * @return void
+     * @return \Generated\Shared\Transfer\QuoteResponseTransfer
      */
-    public function reloadItems(): void
+    public function reloadItems()
     {
         if ($this->isQuoteLocked()) {
             $this->addPermissionFailedMessage();
 
-            return;
+            return (new QuoteResponseTransfer())
+                ->addError((new QuoteErrorTransfer())->setMessage(static::GLOSSARY_KEY_LOCKED_CART_CHANGE_DENIED))
+                ->setIsSuccessful(false);
         }
 
-        $this->quoteStorageStrategy->reloadItems();
+        return $this->quoteStorageStrategy->reloadItems();
     }
 
     /**

--- a/src/Spryker/Client/Cart/Zed/CartStub.php
+++ b/src/Spryker/Client/Cart/Zed/CartStub.php
@@ -98,6 +98,21 @@ class CartStub extends ZedRequestStub implements CartStubInterface
     }
 
     /**
+     * @uses \Spryker\Zed\Cart\Communication\Controller\GatewayController::reloadItemsInQuoteAction()
+     *
+     * @param \Generated\Shared\Transfer\QuoteTransfer $quoteTransfer
+     *
+     * @return \Generated\Shared\Transfer\QuoteResponseTransfer
+     */
+    public function reloadItemsInQuote(QuoteTransfer $quoteTransfer): QuoteResponseTransfer
+    {
+        /** @var \Generated\Shared\Transfer\QuoteResponseTransfer $quoteResponseTransfer */
+        $quoteResponseTransfer = $this->zedStub->call('/cart/gateway/reload-items-in-quote', $quoteTransfer);
+
+        return $quoteResponseTransfer;
+    }
+
+    /**
      * @param \Generated\Shared\Transfer\CartChangeQuantityTransfer $cartChangeQuantityTransfer
      *
      * @return \Generated\Shared\Transfer\QuoteResponseTransfer

--- a/src/Spryker/Client/Cart/Zed/CartStubInterface.php
+++ b/src/Spryker/Client/Cart/Zed/CartStubInterface.php
@@ -43,6 +43,15 @@ interface CartStubInterface
     public function removeItem(CartChangeTransfer $cartChangeTransfer);
 
     /**
+     * @uses \Spryker\Zed\Cart\Communication\Controller\GatewayController::reloadItemsInQuoteAction()
+     *
+     * @param \Generated\Shared\Transfer\QuoteTransfer $quoteTransfer
+     *
+     * @return \Generated\Shared\Transfer\QuoteResponseTransfer
+     */
+    public function reloadItemsInQuote(QuoteTransfer $quoteTransfer): QuoteResponseTransfer;
+
+    /**
      * @param \Generated\Shared\Transfer\CartChangeTransfer $cartChangeTransfer
      *
      * @return \Generated\Shared\Transfer\QuoteResponseTransfer

--- a/src/Spryker/Zed/Cart/Communication/Controller/GatewayController.php
+++ b/src/Spryker/Zed/Cart/Communication/Controller/GatewayController.php
@@ -82,6 +82,16 @@ class GatewayController extends AbstractGatewayController
      *
      * @return \Generated\Shared\Transfer\QuoteResponseTransfer
      */
+    public function reloadItemsInQuoteAction(QuoteTransfer $quoteTransfer): QuoteResponseTransfer
+    {
+        return $this->getFacade()->reloadItemsInQuote($quoteTransfer);
+    }
+
+    /**
+     * @param \Generated\Shared\Transfer\QuoteTransfer $quoteTransfer
+     *
+     * @return \Generated\Shared\Transfer\QuoteResponseTransfer
+     */
     public function validateQuoteAction(QuoteTransfer $quoteTransfer): QuoteResponseTransfer
     {
         return $this->getFacade()->validateQuote($quoteTransfer);


### PR DESCRIPTION
Branch: backport/5.13.0
Ticket: https://spryker.atlassian.net/browse/CC-26572
Target Version: 5.13.0
RG: https://release.spryker.com/release-groups/view/4923

#### Release Table

   Module                | Release Type         | Constraint Updates         |
   :--------------------- | :------------------------ | :--------------------- |
   Cart               | minor                 |           CartExtension            |

#### Release Notes

{skip}

-----------------------------------------

#### Module Cart

##### Change log

Improvements

- Introduced `CartClient::reloadItemsInQuote()`.
- Adjusted `SessionQuoteStorageStrategyPlugin::reloadItems()` to return `QuoteResponse` transfer object instead of `void`.
- Increased `CartExtension` dependency version.